### PR TITLE
Add trailing assignments rule

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,7 @@
             "args": ["--runInBand", "--no-cache", "--runTestsByPath", "${relativeFile}"],
             "cwd": "${workspaceRoot}",
             "protocol": "inspector",
+            "experimentalNetworking": "off",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },
@@ -23,6 +24,7 @@
             "args": ["${workspaceRoot}/dist/cli/dznlint.js", "${relativeFile}"],
             "cwd": "${workspaceRoot}",
             "protocol": "inspector",
+            "experimentalNetworking": "off",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         }

--- a/README.md
+++ b/README.md
@@ -282,3 +282,11 @@ As of Dezyne 2.15, a provided port should be marked blocking if any of its calls
 Function parameters that are ports must be annotated with `provides` or `required`. Function parameters that are not ports must **not** be marked with these two.
 
 **Possible values:** "hint" | "warning" | **"error"**
+
+---
+
+## trailing_assignments
+
+Will find trailing assignments used in interfaces. Trailing assignments can have unexpected effects when using using shared state, so it might be useful to be aware of where trailing assignments are used, or to disallow them completely.
+
+**Possible values:** "hint" | "warning" | "error" (default: off)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dznlint",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dznlint",
-            "version": "2.0.0-beta.3",
+            "version": "2.0.0-beta.4",
             "dependencies": {
                 "web-tree-sitter": "^0.22.6"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dznlint",
-    "version": "2.0.0-beta.4",
+    "version": "2.0.0-beta.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dznlint",
-            "version": "2.0.0-beta.4",
+            "version": "2.0.0-beta.5",
             "dependencies": {
                 "web-tree-sitter": "^0.22.6"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dznlint",
-    "version": "2.0.0-beta.6",
+    "version": "2.0.0-beta.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dznlint",
-            "version": "2.0.0-beta.6",
+            "version": "2.0.0-beta.7",
             "dependencies": {
                 "web-tree-sitter": "^0.22.6"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dznlint",
-    "version": "2.0.0-beta.5",
+    "version": "2.0.0-beta.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dznlint",
-            "version": "2.0.0-beta.5",
+            "version": "2.0.0-beta.6",
             "dependencies": {
                 "web-tree-sitter": "^0.22.6"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dznlint",
-    "version": "2.0.0-beta.5",
+    "version": "2.0.0-beta.6",
     "description": "A linter for Dezyne .dzn files. Providing extra warnings and coding style analysis.",
     "repository": "https://github.com/Perryvw/dznlint",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dznlint",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "A linter for Dezyne .dzn files. Providing extra warnings and coding style analysis.",
     "repository": "https://github.com/Perryvw/dznlint",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dznlint",
-    "version": "2.0.0-beta.6",
+    "version": "2.0.0-beta.7",
     "description": "A linter for Dezyne .dzn files. Providing extra warnings and coding style analysis.",
     "repository": "https://github.com/Perryvw/dznlint",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dznlint",
-    "version": "2.0.0-beta.4",
+    "version": "2.0.0-beta.5",
     "description": "A linter for Dezyne .dzn files. Providing extra warnings and coding style analysis.",
     "repository": "https://github.com/Perryvw/dznlint",
     "files": [

--- a/src/config/default-config.ts
+++ b/src/config/default-config.ts
@@ -43,6 +43,7 @@ export const DEFAULT_DZNLINT_CONFIG: DefaultDznLintConfig = {
     parameter_direction: "warning",
     port_missing_redundant_blocking: false,
     port_parameter_direction: "error",
+    trailing_assignments: false,
 };
 
 export const DEFAULT_DZNLINT_FORMAT_CONFIG: DznLintFormatConfiguration = {

--- a/src/config/dznlint-configuration.ts
+++ b/src/config/dznlint-configuration.ts
@@ -44,6 +44,7 @@ export interface DznLintConfiguration {
     parameter_direction: ConfigValue;
     port_missing_redundant_blocking: ConfigValue;
     port_parameter_direction: ConfigValue;
+    trailing_assignments: ConfigValue;
 }
 
 export type UserRuleConfig<TRule extends keyof DznLintConfiguration> =

--- a/src/linting-rule.ts
+++ b/src/linting-rule.ts
@@ -38,6 +38,7 @@ import parameter_direction from "./rules/parameter-direction";
 import no_unused_instances from "./rules/no-unused-instances";
 import { port_missing_redundant_blocking } from "./rules/port-missing-redundant-blocking";
 import port_parameter_direction from "./rules/port-parameter-direction";
+import trailing_assignments from "./rules/trailing-assignments";
 
 export function loadLinters(config: DznLintUserConfiguration) {
     const factories = [
@@ -67,6 +68,7 @@ export function loadLinters(config: DznLintUserConfiguration) {
         parameter_direction,
         port_missing_redundant_blocking,
         port_parameter_direction,
+        trailing_assignments,
     ];
 
     const linters = new Map<ast.SyntaxKind, Linter<ast.AnyAstNode>[]>();

--- a/src/rules/trailing-assignments.ts
+++ b/src/rules/trailing-assignments.ts
@@ -1,0 +1,59 @@
+// Trailing assignments can lead to unexpected state behavior when using shared state
+
+import * as ast from "../grammar/ast";
+import { getRuleConfig } from "../config/util";
+import { createDiagnosticsFactory, Diagnostic } from "../diagnostic";
+import { RuleFactory } from "../linting-rule";
+import { isAssignment, isCallExpression, isCompound, isExpressionStatement, isOnStatement, isReply } from "../util";
+
+export const trailingAssignment = createDiagnosticsFactory();
+
+export const trailing_assignments: RuleFactory = factoryContext => {
+    const config = getRuleConfig("trailing_assignments", factoryContext.userConfig);
+
+    if (config.isEnabled) {
+        factoryContext.registerRule<ast.InterfaceDefinition>(ast.SyntaxKind.InterfaceDefinition, (node, context) => {
+            if (!node.behavior) {
+                return [];
+            }
+
+            const diagnostics: Diagnostic[] = [];
+
+            // Check all on-statements in the interface behavior
+            context.visit(node.behavior, subNode => {
+                if (isOnStatement(subNode) && isCompound(subNode.body)) {
+                    let assignmentsAllowed = true;
+                    for (const statement of subNode.body.statements) {
+                        // After seeing a reply or expression statement, assignments are no longer allowed
+                        if (
+                            isExpressionStatement(statement) &&
+                            (isCallExpression(statement.expression) || isReply(statement.expression))
+                        ) {
+                            assignmentsAllowed = false;
+                            continue;
+                        }
+
+                        if (isAssignment(statement)) {
+                            // When encountering an assignment, check if it is allowed at this point
+                            if (!assignmentsAllowed) {
+                                // If not, add diagnostic
+                                diagnostics.push(
+                                    trailingAssignment(
+                                        config.severity,
+                                        `Trailing assignments can lead to unexpected state behavior when using shared state`,
+                                        context.source,
+                                        statement.position
+                                    )
+                                );
+                            }
+                        }
+                    }
+                }
+            });
+
+            return diagnostics;
+        });
+    }
+};
+
+export default trailing_assignments;

--- a/src/rules/trailing-assignments.ts
+++ b/src/rules/trailing-assignments.ts
@@ -4,7 +4,7 @@ import * as ast from "../grammar/ast";
 import { getRuleConfig } from "../config/util";
 import { createDiagnosticsFactory, Diagnostic } from "../diagnostic";
 import { RuleFactory } from "../linting-rule";
-import { isAssignment, isCallExpression, isCompound, isExpressionStatement, isOnStatement, isReply } from "../util";
+import { isAssignment, isCompound, isExpressionStatement, isIdentifier, isOnStatement, isReply } from "../util";
 
 export const trailingAssignment = createDiagnosticsFactory();
 
@@ -27,7 +27,7 @@ export const trailing_assignments: RuleFactory = factoryContext => {
                         // After seeing a reply or expression statement, assignments are no longer allowed
                         if (
                             isExpressionStatement(statement) &&
-                            (isCallExpression(statement.expression) || isReply(statement.expression))
+                            (isIdentifier(statement.expression) || isReply(statement.expression))
                         ) {
                             assignmentsAllowed = false;
                             continue;

--- a/src/util.ts
+++ b/src/util.ts
@@ -204,6 +204,10 @@ export function isKeyword(node: ast.AnyAstNode): node is ast.Keyword<any> {
     return node.kind === ast.SyntaxKind.Keyword;
 }
 
+export function isAssignment(statement: ast.AnyAstNode): statement is ast.AssignmentStatement {
+    return statement.kind === ast.SyntaxKind.AssignmentStatement;
+}
+
 export function isExtern(statement: ast.AnyAstNode): statement is ast.ExternDeclaration {
     return statement.kind === ast.SyntaxKind.ExternDeclaration;
 }

--- a/test/trailing-assignments.spec.ts
+++ b/test/trailing-assignments.spec.ts
@@ -1,0 +1,122 @@
+import { trailingAssignment } from "../src/rules/trailing-assignments";
+import { testdznlint } from "./util";
+
+test("trailing assignment after out event", async () => {
+    await testdznlint({
+        diagnostic: trailingAssignment.code,
+        config: { trailing_assignments: "warning" },
+        pass: `
+            interface IA {
+                in void f();
+                out void bla();
+
+                behavior {
+                    enum State {
+                        A,
+                        B
+                    };
+                    State s = State.A;
+
+                    [s.A] {
+                        on f: {
+                            s = State.B;
+                            foo();
+                        }
+                    }
+                }
+            }`,
+        fail: `
+            interface IA {
+                in void f();
+                out void bla();
+
+                behavior {
+                    enum State {
+                        A,
+                        B
+                    };
+                    State s = State.A;
+
+                    [s.A] {
+                        on f: {
+                            foo();
+                            s = State.B;
+                        }
+                    }
+                }
+            }`,
+    });
+});
+
+test("trailing assignment after reply", async () => {
+    await testdznlint({
+        diagnostic: trailingAssignment.code,
+        config: { trailing_assignments: "warning" },
+        pass: `
+            interface IA {
+                in void f();
+                out void bla();
+
+                behavior {
+                    enum State {
+                        A,
+                        B
+                    };
+                    State s = State.A;
+
+                    [s.A] {
+                        on f: {
+                            s = State.B;
+                            reply();
+                        }
+                    }
+                }
+            }`,
+        fail: `
+            interface IA {
+                in void f();
+                out void bla();
+
+                behavior {
+                    enum State {
+                        A,
+                        B
+                    };
+                    State s = State.A;
+
+                    [s.A] {
+                        on f: {
+                            reply();
+                            s = State.B;
+                        }
+                    }
+                }
+            }`,
+    });
+});
+
+test("trailing assignment no issue on component", async () => {
+    await testdznlint({
+        diagnostic: trailingAssignment.code,
+        config: { trailing_assignments: "warning" },
+        pass: `
+            component C {
+                provides I i;
+
+                behavior {
+                    enum State {
+                        A,
+                        B
+                    };
+                    State s = State.A;
+
+                    [s.A] {
+                        on i.f: {
+                            i.foo();
+                            s = State.B;
+                        }
+                    }
+                }
+            }`,
+    });
+});

--- a/test/trailing-assignments.spec.ts
+++ b/test/trailing-assignments.spec.ts
@@ -20,7 +20,7 @@ test("trailing assignment after out event", async () => {
                     [s.A] {
                         on f: {
                             s = State.B;
-                            foo();
+                            bla;
                         }
                     }
                 }
@@ -39,7 +39,7 @@ test("trailing assignment after out event", async () => {
 
                     [s.A] {
                         on f: {
-                            foo();
+                            bla;
                             s = State.B;
                         }
                     }


### PR DESCRIPTION
Add a new rule `trailing_assignments` that is disabled by default.

When enabled via configuration, it will highlight any trailing assignments done in interface behaviors. These trailing assignments can lead to unexpected behavior when using shared state, so in some cases it might be useful to have a warning for them. 