### PR TITLE
Add rule that errors when using a parameter list for events in interface behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ Defer statements should capture one or more state variables to prevent unexpecte
 
 ---
 
+## no_interface_event_parameters
+
+In interface behaviors, events should not mention any parameters, this is invalid Dezyne code.
+
+**Possible values:** "hint" | "warning" | **"error"**
+
+---
+
 ## no_recursive_system
 
 Systems cannot contain instances of themself.

--- a/src/config/default-config.ts
+++ b/src/config/default-config.ts
@@ -29,6 +29,7 @@ export const DEFAULT_DZNLINT_CONFIG: DefaultDznLintConfig = {
     no_duplicate_parameters: "error",
     no_duplicate_port_binding: "error",
     no_empty_defer_capture: "warning",
+    no_interface_event_parameters: "error",
     no_mismatching_binding_types: "error",
     no_recursive_system: "error",
     no_shadowing: "warning",

--- a/src/config/dznlint-configuration.ts
+++ b/src/config/dznlint-configuration.ts
@@ -30,6 +30,7 @@ export interface DznLintConfiguration {
     no_duplicate_parameters: ConfigValue;
     no_duplicate_port_binding: ConfigValue;
     no_empty_defer_capture: ConfigValue;
+    no_interface_event_parameters: ConfigValue;
     no_mismatching_binding_types: ConfigValue;
     no_recursive_system: ConfigValue;
     no_shadowing: ConfigValue;

--- a/src/linting-rule.ts
+++ b/src/linting-rule.ts
@@ -26,6 +26,7 @@ import no_bool_out_parameters from "./rules/no-bool-out-parameters";
 import no_duplicate_parameters from "./rules/no-duplicate-parameters";
 import no_duplicate_port_binding from "./rules/no-duplicate-port-binding";
 import no_empty_defer_capture from "./rules/no-empty-defer-capture";
+import no_interface_event_parameters from "./rules/no-interface-event-parameters";
 import no_mismatching_binding_types from "./rules/no-mismatching-binding-types";
 import no_unconnected_ports from "./rules/no-unconnected-ports";
 import no_unknown_imports from "./rules/no-unknown-imports";
@@ -54,6 +55,7 @@ export function loadLinters(config: DznLintUserConfiguration) {
         no_duplicate_parameters,
         no_duplicate_port_binding,
         no_empty_defer_capture,
+        no_interface_event_parameters,
         no_mismatching_binding_types,
         no_recursive_system,
         no_shadowing,

--- a/src/rules/call-arguments-must-match.ts
+++ b/src/rules/call-arguments-must-match.ts
@@ -41,7 +41,7 @@ export const call_arguments_must_match: RuleFactory = factoryContext => {
                     );
                 }
             } else if (
-                functionType.kind === TypeKind.Function &&
+                functionType.kind === TypeKind.Event &&
                 functionType.declaration &&
                 isEvent(functionType.declaration)
             ) {

--- a/src/rules/no-interface-event-parameters.ts
+++ b/src/rules/no-interface-event-parameters.ts
@@ -1,0 +1,80 @@
+// Events in interface behavior should not mention parameters, not in on triggers, and not in behavior compounds
+
+import * as ast from "../grammar/ast";
+import { getRuleConfig } from "../config/util";
+import { createDiagnosticsFactory, Diagnostic } from "../diagnostic";
+import { RuleFactory } from "../linting-rule";
+import { isCallExpression, isCompound, isExpressionStatement, isKeyword, isOnStatement } from "../util";
+import { TypeKind } from "../semantics";
+
+export const invalidInterfaceOnTrigger = createDiagnosticsFactory();
+export const invalidInterfaceEventCall = createDiagnosticsFactory();
+
+export const no_interface_event_parameters: RuleFactory = factoryContext => {
+    const config = getRuleConfig("no_interface_event_parameters", factoryContext.userConfig);
+
+    if (config.isEnabled) {
+        factoryContext.registerRule<ast.InterfaceDefinition>(ast.SyntaxKind.InterfaceDefinition, (node, context) => {
+            const diagnostics: Diagnostic[] = [];
+
+            if (node.behavior) {
+                context.visit(node.behavior, subNode => {
+                    if (isOnStatement(subNode)) {
+                        // Check on triggers
+                        for (const trigger of subNode.triggers) {
+                            if (!isKeyword(trigger) && trigger.parameterList) {
+                                diagnostics.push(
+                                    invalidInterfaceOnTrigger(
+                                        config.severity,
+                                        `Events in interface behavior should not mention their parameters, only the event occurrence matters and not the data. Remove this parameter list.`,
+                                        context.source,
+                                        trigger.parameterList.position
+                                    )
+                                );
+                            }
+                        }
+
+                        // Check on body
+                        if (isCompound(subNode.body)) {
+                            // Check all statements in compound body
+                            for (const statement of subNode.body.statements) {
+                                if (isExpressionStatement(statement) && isCallExpression(statement.expression)) {
+                                    const calledExpression = statement.expression.expression;
+                                    const type = context.typeChecker.typeOfNode(calledExpression);
+                                    if (type.kind === TypeKind.Event) {
+                                        diagnostics.push(
+                                            invalidInterfaceEventCall(
+                                                config.severity,
+                                                `Events in interface behavior should not mention their arguments, only the event occurrence matters and not the data. Remove this argument list.`,
+                                                context.source,
+                                                statement.expression.arguments.position
+                                            )
+                                        );
+                                    }
+                                }
+                            }
+                        } else if (isExpressionStatement(subNode.body) && isCallExpression(subNode.body.expression)) {
+                            // If body is a single call expression, also check that
+                            const calledExpression = subNode.body.expression.expression;
+                            const type = context.typeChecker.typeOfNode(calledExpression);
+                            if (type.kind === TypeKind.Event) {
+                                diagnostics.push(
+                                    invalidInterfaceEventCall(
+                                        config.severity,
+                                        `Events in interface behavior should not mention their arguments, only the event occurrence matters and not the data. Remove this argument list.`,
+                                        context.source,
+                                        subNode.body.expression.arguments.position
+                                    )
+                                );
+                            }
+                        }
+                    }
+                });
+            }
+
+            return diagnostics;
+        });
+    }
+};
+
+export default no_interface_event_parameters;

--- a/src/rules/on-parameters-must-match.ts
+++ b/src/rules/on-parameters-must-match.ts
@@ -22,7 +22,7 @@ export const on_parameters_must_match: RuleFactory = factoryContext => {
                 const triggerType = context.typeChecker.typeOfNode(trigger.name);
 
                 if (
-                    triggerType.kind === TypeKind.Function &&
+                    triggerType.kind === TypeKind.Event &&
                     triggerType.declaration &&
                     isEvent(triggerType.declaration)
                 ) {

--- a/test/no-interface-event-parameters.spec.ts
+++ b/test/no-interface-event-parameters.spec.ts
@@ -1,0 +1,101 @@
+import { invalidInterfaceEventCall, invalidInterfaceOnTrigger } from "../src/rules/no-interface-event-parameters";
+import { testdznlint } from "./util";
+
+test("interface on triggers should not have a parameter list", async () => {
+    await testdznlint({
+        diagnostic: invalidInterfaceOnTrigger.code,
+        fail: `
+            interface I {
+                in void foo(in bool a);
+
+                behavior {
+                    on foo(a): {}
+                }
+            }`,
+        pass: `
+            interface I {
+                in void foo(in bool a);
+
+                behavior {
+                    on foo: {}
+                }
+            }`,
+    });
+});
+
+test("component on should have a parameter list", async () => {
+    await testdznlint({
+        diagnostic: invalidInterfaceOnTrigger.code,
+        pass: `
+            component C {
+                provides I i;
+
+                behavior {
+                    on i.foo(): {}
+                }
+            }`,
+    });
+});
+
+test("interface event calls should not have arguments", async () => {
+    await testdznlint({
+        diagnostic: invalidInterfaceEventCall.code,
+        debug: true,
+        fail: `
+            interface I {
+                in void foo();
+                out void bar(in bool b);
+
+                behavior {
+                    on foo: {
+                        bar(true);
+                    }
+                }
+            }`,
+        pass: `
+            interface I {
+                in void foo();
+                out void bar(in bool b);
+
+                behavior {
+                    on foo: {
+                        bar;
+                    }
+                }
+            }`,
+    });
+});
+
+test("single-line interface event calls also should not have arguments", async () => {
+    await testdznlint({
+        diagnostic: invalidInterfaceEventCall.code,
+        fail: `
+            interface I {
+                in void foo();
+                out void bar(in bool b);
+
+                behavior {
+                    on foo: bar(true);
+                }
+            }`,
+    });
+});
+
+test("function calls in interface behavior do need a parameter list", async () => {
+    await testdznlint({
+        diagnostic: invalidInterfaceEventCall.code,
+        pass: `
+            interface I {
+                in void foo();
+                out void bar(in bool b);
+
+                behavior {
+                    on foo: {
+                        bla(true);
+                    }
+
+                    void bla(in bool p) {}
+                }
+            }`,
+    });
+});

--- a/test/no-interface-event-parameters.spec.ts
+++ b/test/no-interface-event-parameters.spec.ts
@@ -23,6 +23,20 @@ test("interface on triggers should not have a parameter list", async () => {
     });
 });
 
+test("empty parameter lists are also not okay", async () => {
+    await testdznlint({
+        diagnostic: invalidInterfaceOnTrigger.code,
+        fail: `
+            interface I {
+                in void foo();
+
+                behavior {
+                    on foo(): {}
+                }
+            }`,
+    });
+});
+
 test("component on should have a parameter list", async () => {
     await testdznlint({
         diagnostic: invalidInterfaceOnTrigger.code,


### PR DESCRIPTION
Valid:
```dzn
interface I {
    in void foo(in bool b);
    out void bar();

    behavior {
        on foo: {
            bar;
        }
    }
}
```

Invalid:
```dzn
interface I {
    in void foo(in bool b);

    behavior {
        on foo(b): { // (b) not allowed
            bar(); // () not allowed
        }
    }
}
```